### PR TITLE
fix memory issue when adding a resource

### DIFF
--- a/include/plugins/resources.h
+++ b/include/plugins/resources.h
@@ -424,7 +424,7 @@ tc_bool tico_plugin_resources_add(tc_ResourceManager *manager, const char *type,
 
 	int type_len = strlen(resource->type);
 	int name_len = strlen(resource->name);
-  int size = name_len + type_len + 2;
+  int size = name_len + type_len + 3;
   char key[size];
   sprintf(key, "%s//%s", resource->type, resource->name);
   char **uuid = map_get(&manager->keys, key);


### PR DESCRIPTION
This PR fixes the #7 issue.

`resource->data` was being overwritten with `NULL` on the `sprintf` call.

I added one more entry space for the key array to add the space for the
`\0` character.

After this change, the bug didn't happened anymore.